### PR TITLE
Rename 'permalink' to 'routeName'

### DIFF
--- a/src/components/ArchivePanel.svelte
+++ b/src/components/ArchivePanel.svelte
@@ -23,7 +23,7 @@ interface Post {
         tags: string[];
         category?: string;
         published: Date;
-		permalink?: string; // 添加 permalink 字段
+        routeName?: string; // 添加 routeName 字段
     };
 }
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -24,8 +24,8 @@ const postsCollection = defineCollection({
         encrypted: z.boolean().optional().default(false),
         password: z.string().optional().default(""),
 
-        /* Custom permalink */
-        permalink: z.string().optional(),
+        /* Custom routeName */
+        routeName: z.string().optional(),
 
         /* For internal use */
         prevTitle: z.string().default(""),

--- a/src/content/posts/encryption.md
+++ b/src/content/posts/encryption.md
@@ -5,6 +5,7 @@ description: This is an article for testing the page encryption feature
 encrypted: true
 pinned: false
 password: "123456"
+routeName: "encrypted-example"
 tags: [Encryption]
 category: Examples
 ---
@@ -28,19 +29,20 @@ draft: false
 ```
 
 
-| Attribute     | Description                                                                                                                                                                                                 |
-|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `title`       | The title of the post.                                                                                                                                                                                      |
-| `published`   | The date the post was published.                                                                                                                                                                            |
-| `pinned`      | Whether this post is pinned to the top of the post list.                                                                                                                                                   |
-| `description` | A short description of the post. Displayed on index page.                                                                                                                                                   |
-| `image`       | The cover image path of the post.<br/>1. Start with `http://` or `https://`: Use web image<br/>2. Start with `/`: For image in `public` dir<br/>3. With none of the prefixes: Relative to the markdown file |
-| `tags`        | The tags of the post.                                                                                                                                                                                       |
-| `category`    | The category of the post.                                                                                                                                                                                   |
-| `licenseName` | The license name for the post content.                                                                                                                                                                      |
-| `author`      | The author of the post.                                                                                                                                                                                     |
-| `sourceLink`  | The source link or reference for the post content.                                                                                                                                                          |
-| `draft`       | If this post is still a draft, which won't be displayed.                                                                                                                                                    |
+| Attribute     | Description |
+|---------------|-------------|
+| `title`       | The title of the post. |
+| `published`   | The date the post was published. |
+| `pinned`      | Whether this post is pinned to the top of the post list. |
+| `description` | A short description of the post. Displayed on index page. |
+| `image`       | The cover image path of the post. <br/>1. Start with `http://` or `https://`: Use web image <br/>2. Start with `/`: For image in `public` dir <br/>3. With none of the prefixes: Relative to the markdown file |
+| `tags`        | The tags of the post. |
+| `category`    | The category of the post. |
+| `routeName`   | Route name for the post. The post will be accessible at `/posts/{routeName}/` |
+| `licenseName` | The license name for the post content. |
+| `author`      | The author of the post. |
+| `sourceLink`  | The source link or reference for the post content. |
+| `draft`       | If this post is still a draft, which won't be displayed. |
 
 
 ## Where to Place the Post Files

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -23,38 +23,38 @@ import { formatDateToYYYYMMDD } from "../../utils/date-utils";
 
 
 export async function getStaticPaths() {
-	const blogEntries = await getSortedPosts();
-	const paths: {
-		params: { slug: string };
-		props: { entry: CollectionEntry<"posts"> };
-	}[] = [];
+    const blogEntries = await getSortedPosts();
+    const paths: {
+        params: { slug: string };
+        props: { entry: CollectionEntry<"posts"> };
+    }[] = [];
 
-	for (const entry of blogEntries) {
-		// 将 id 转换为 slug（移除扩展名）以匹配路由参数
-		const slug = removeFileExtension(entry.id);
-		// 为每篇文章创建默认的 slug 路径
-		paths.push({
-			params: { slug },
-			props: { entry },
-		});
-		// 如果文章有自定义固定链接，也创建对应的路径
-		if (entry.data.permalink) {
-			// 移除开头的斜杠和结尾的斜杠
-			// 同时移除可能的 "posts/" 前缀，避免重复
-			let permalink = entry.data.permalink
-				.replace(/^\/+/, "")
-				.replace(/\/+$/, "");
-			if (permalink.startsWith("posts/")) {
-				permalink = permalink.replace(/^posts\//, "");
-			}
-			paths.push({
-				params: { slug: permalink },
-				props: { entry },
-			});
-		}
-	}
+    for (const entry of blogEntries) {
+        // 将 id 转换为 slug（移除扩展名）以匹配路由参数
+        const slug = removeFileExtension(entry.id);
+        // 为每篇文章创建默认的 slug 路径
+        paths.push({
+            params: { slug },
+            props: { entry },
+        });
+        // 如果文章有自定义固定链接，也创建对应的路径
+        if (entry.data.routeName) {
+            // 移除开头的斜杠和结尾的斜杠
+            // 同时移除可能的 "posts/" 前缀，避免重复
+            let routeName = entry.data.routeName
+                .replace(/^\/+/, "")
+                .replace(/\/+$/, "");
+            if (routeName.startsWith("posts/")) {
+                routeName = routeName.replace(/^posts\//, "");
+            }
+            paths.push({
+                params: { slug: routeName },
+                props: { entry },
+            });
+        }
+    }
 
-	return paths;
+    return paths;
 }
 
 
@@ -69,42 +69,42 @@ let passwordHash = "";
 let isEncrypted = entry.data.encrypted && entry.data.password;
 
 if (isEncrypted) {
-	// 对于加密文章，我们将使用内容进行加密
-	// 在客户端解密后，会通过JavaScript重新渲染
-	const contentToEncrypt = entry.body;
+    // 对于加密文章，我们将使用内容进行加密
+    // 在客户端解密后，会通过JavaScript重新渲染
+    const contentToEncrypt = entry.body;
 
-	// 使用AES加密内容
-	encryptedContent = CryptoJS.AES.encrypt(
-		contentToEncrypt,
-		entry.data.password,
-	).toString();
+    // 使用AES加密内容
+    encryptedContent = CryptoJS.AES.encrypt(
+        contentToEncrypt,
+        entry.data.password,
+    ).toString();
 
-	// 生成密码哈希
-	const saltRounds = 10;
-	passwordHash = bcryptjs.hashSync(entry.data.password, saltRounds);
+    // 生成密码哈希
+    const saltRounds = 10;
+    passwordHash = bcryptjs.hashSync(entry.data.password, saltRounds);
 }
 
 dayjs.extend(utc);
 const lastModified = dayjs(entry.data.updated || entry.data.published)
-	.utc()
-	.format("YYYY-MM-DDTHH:mm:ss");
+    .utc()
+    .format("YYYY-MM-DDTHH:mm:ss");
 
 const jsonLd = {
-	"@context": "https://schema.org",
-	"@type": "BlogPosting",
-	headline: entry.data.title,
-	description: entry.data.description || entry.data.title,
-	keywords: entry.data.tags,
-	author: {
-		"@type": "Person",
-		name: profileConfig.name,
-		url: Astro.site,
-	},
-	datePublished: formatDateToYYYYMMDD(entry.data.published),
-	inLanguage: entry.data.lang
-		? entry.data.lang.replace("_", "-")
-		: siteConfig.lang.replace("_", "-"),
-	// TODO include cover image here
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: entry.data.title,
+    description: entry.data.description || entry.data.title,
+    keywords: entry.data.tags,
+    author: {
+        "@type": "Person",
+        name: profileConfig.name,
+        url: Astro.site,
+    },
+    datePublished: formatDateToYYYYMMDD(entry.data.published),
+    inLanguage: entry.data.lang
+        ? entry.data.lang.replace("_", "-")
+        : siteConfig.lang.replace("_", "-"),
+    // TODO include cover image here
 };
 ---
 
@@ -253,8 +253,8 @@ const jsonLd = {
 
     {postConfig.showLastModified && (
         <>
-            <div 
-                id="last-modified" 
+            <div
+                id="last-modified"
                 data-last-modified={lastModified}
                 data-prefix={i18n(I18nKey.lastModifiedPrefix)}
                 data-year={i18n(I18nKey.year)}
@@ -293,7 +293,7 @@ const jsonLd = {
                         const secondKey = lastModifiedElement.dataset.second;
 
                         let runtimeString = prefix + ' ';
-                        
+
                         if (years > 0) {
                             runtimeString += `${years} ${yearKey} `;
                         }
@@ -327,7 +327,7 @@ const jsonLd = {
                                 class="text-4xl text-[var(--primary)] transition-transform group-hover:translate-x-0.5 bg-[var(--enter-btn-bg)] p-2 rounded-md"
                             />
                         </div>
-                       
+
                         <div class="flex flex-col gap-0.1">
                             <div id="modifiedtime" class="text-[1.0rem] leading-tight text-black/75 dark:text-white/75"></div>
                             <p class="text-[0.8rem] leading-tight text-black/75 dark:text-white/75">

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -4,72 +4,72 @@ import { i18n } from "@i18n/translation";
 
 
 export function pathsEqual(path1: string, path2: string) {
-	const normalizedPath1 = path1.replace(/^\/|\/$/g, "").toLowerCase();
-	const normalizedPath2 = path2.replace(/^\/|\/$/g, "").toLowerCase();
-	return normalizedPath1 === normalizedPath2;
+    const normalizedPath1 = path1.replace(/^\/|\/$/g, "").toLowerCase();
+    const normalizedPath2 = path2.replace(/^\/|\/$/g, "").toLowerCase();
+    return normalizedPath1 === normalizedPath2;
 }
 
 function joinUrl(...parts: string[]): string {
-	const joined = parts.join("/");
-	return joined.replace(/\/+/g, "/");
+    const joined = parts.join("/");
+    return joined.replace(/\/+/g, "/");
 }
 
 export function removeFileExtension(id: string): string {
-	return id.replace(/\.(md|mdx|markdown)$/i, "");
+    return id.replace(/\.(md|mdx|markdown)$/i, "");
 }
 
 export function getPostUrlBySlug(slug: string): string {
-	// 移除文件扩展名（如 .md, .mdx 等）
-	const slugWithoutExt = removeFileExtension(slug);
-	return url(`/posts/${slugWithoutExt}/`);
+    // 移除文件扩展名（如 .md, .mdx 等）
+    const slugWithoutExt = removeFileExtension(slug);
+    return url(`/posts/${slugWithoutExt}/`);
 }
 
-export function getPostUrlByPermalink(permalink: string): string {
-	// 移除开头的斜杠并确保固定链接在 /posts/ 路径下
-	const cleanPermalink = permalink.replace(/^\/+/, "");
-	return url(`/posts/${cleanPermalink}/`);
+export function getPostUrlByRouteName(routeName: string): string {
+    // 移除开头的斜杠并确保固定链接在 /posts/ 路径下
+    const cleanRouteName = routeName.replace(/^\/+/, "");
+    return url(`/posts/${cleanRouteName}/`);
 }
 
 export function getPostUrl(post: CollectionEntry<"posts">): string;
-export function getPostUrl(post: { id: string; data: { permalink?: string } }): string;
+export function getPostUrl(post: { id: string; data: { routeName?: string } }): string;
 export function getPostUrl(post: any): string {
-	// 如果文章有自定义固定链接，优先使用固定链接
-	if (post.data.permalink) {
-		return getPostUrlByPermalink(post.data.permalink);
-	}
-	// 否则使用默认的 slug 路径
-	return getPostUrlBySlug(post.id);
+    // 如果文章有自定义固定链接，优先使用固定链接
+    if (post.data.routeName) {
+        return getPostUrlByRouteName(post.data.routeName);
+    }
+    // 否则使用默认的 slug 路径
+    return getPostUrlBySlug(post.id);
 }
 
 export function getTagUrl(tag: string): string {
-	if (!tag) return url("/archive/");
-	return url(`/archive/?tag=${encodeURIComponent(tag.trim())}`);
+    if (!tag) return url("/archive/");
+    return url(`/archive/?tag=${encodeURIComponent(tag.trim())}`);
 }
 
 export function getCategoryUrl(category: string | null): string {
-	if (
-		!category ||
-		category.trim() === "" ||
-		category.trim().toLowerCase() === i18n(I18nKey.uncategorized).toLowerCase()
-	)
-		return url("/archive/?uncategorized=true");
-	return url(`/archive/?category=${encodeURIComponent(category.trim())}`);
+    if (
+        !category ||
+        category.trim() === "" ||
+        category.trim().toLowerCase() === i18n(I18nKey.uncategorized).toLowerCase()
+    )
+        return url("/archive/?uncategorized=true");
+    return url(`/archive/?category=${encodeURIComponent(category.trim())}`);
 }
 
 export function getDir(path: string): string {
-	// 移除文件扩展名
-	const pathWithoutExt = removeFileExtension(path);
-	const lastSlashIndex = pathWithoutExt.lastIndexOf("/");
-	if (lastSlashIndex < 0) {
-		return "/";
-	}
-	return pathWithoutExt.substring(0, lastSlashIndex + 1);
+    // 移除文件扩展名
+    const pathWithoutExt = removeFileExtension(path);
+    const lastSlashIndex = pathWithoutExt.lastIndexOf("/");
+    if (lastSlashIndex < 0) {
+        return "/";
+    }
+    return pathWithoutExt.substring(0, lastSlashIndex + 1);
 }
 
 export function getFileDirFromPath(filePath: string): string {
-	return filePath.replace(/^src\//, "").replace(/\/[^/]+$/, "");
+    return filePath.replace(/^src\//, "").replace(/\/[^/]+$/, "");
 }
 
 export function url(path: string) {
-	return joinUrl("", import.meta.env.BASE_URL, path);
+    return joinUrl("", import.meta.env.BASE_URL, path);
 }


### PR DESCRIPTION
- Rename 'permalink' to 'routeName' for better readability
- Add ‘routeName’ to encryption.md as example
- Convert indentation to spaces
