### PR TITLE
fix(stats): make ECharts text follow global font

### DIFF
--- a/src/components/sidebar/statistics.svelte
+++ b/src/components/sidebar/statistics.svelte
@@ -63,6 +63,14 @@
         };
     };
 
+    const getChartsFontFamily = () => {
+        const fallback = "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif";
+        if (typeof window === 'undefined') return fallback;
+        const target = container ?? document.body ?? document.documentElement;
+        const fontFamily = window.getComputedStyle(target).fontFamily;
+        return fontFamily && fontFamily !== 'inherit' ? fontFamily : fallback;
+    };
+
     const loadECharts = async () => {
         if (typeof window === 'undefined') return;
         isDark = document.documentElement.classList.contains('dark');
@@ -114,6 +122,7 @@
         }
 
         const colors = getThemeColors();
+        const fontFamily = getChartsFontFamily();
 
         const now = dayjs();
         let data: any[] = [];
@@ -155,13 +164,14 @@
 
         const option = {
             backgroundColor: 'transparent',
+            textStyle: { fontFamily },
             animation: isNew || isUpdate,
             animationDuration: isNew ? 2000 : 500,
             animationEasing: 'cubicOut',
             title: {
                 text: labels.activities,
                 left: 'left',
-                textStyle: { fontSize: 14, color: colors.text, fontWeight: 'bold' }
+                textStyle: { fontFamily, fontSize: 14, color: colors.text, fontWeight: 'bold' }
             },
             tooltip: {
                 trigger: 'axis',
@@ -173,13 +183,13 @@
                 type: 'category',
                 data: xAxisData,
                 axisLine: { lineStyle: { color: colors.grid } },
-                axisLabel: { color: colors.text, fontSize: 10 }
+                axisLabel: { fontFamily, color: colors.text, fontSize: 10 }
             },
             yAxis: {
                 type: 'value',
                 minInterval: 1,
                 axisLine: { show: false },
-                axisLabel: { color: colors.text, fontSize: 10 },
+                axisLabel: { fontFamily, color: colors.text, fontSize: 10 },
                 splitLine: { lineStyle: { color: colors.grid, type: 'dashed' } }
             },
             series: [{
@@ -205,6 +215,7 @@
     const initRadarCharts = () => {
         if (!echarts) return;
         const colors = getThemeColors();
+        const fontFamily = getChartsFontFamily();
 
         // Categories Radar
         if (categoriesContainer) {
@@ -220,6 +231,7 @@
 
             categoriesChart.setOption({
                 backgroundColor: 'transparent',
+                textStyle: { fontFamily },
                 animation: true,
                 animationDuration: 2000,
                 animationEasing: 'exponentialOut',
@@ -231,13 +243,13 @@
                 title: {
                     text: labels.categories,
                     left: 'left',
-                    textStyle: { fontSize: 14, color: colors.text, fontWeight: 'bold' }
+                    textStyle: { fontFamily, fontSize: 14, color: colors.text, fontWeight: 'bold' }
                 },
                 radar: {
                     indicator: indicator,
                     radius: '60%',
                     center: ['50%', '60%'],
-                    axisName: { color: colors.text, fontSize: 10 },
+                    axisName: { fontFamily, color: colors.text, fontSize: 10 },
                     splitLine: { lineStyle: { color: colors.grid } },
                     splitArea: { show: false }
                 },
@@ -269,6 +281,7 @@
 
             tagsChart.setOption({
                 backgroundColor: 'transparent',
+                textStyle: { fontFamily },
                 animation: true,
                 animationDuration: 2000,
                 animationEasing: 'exponentialOut',
@@ -280,13 +293,13 @@
                 title: {
                     text: labels.tags,
                     left: 'left',
-                    textStyle: { fontSize: 14, color: colors.text, fontWeight: 'bold' }
+                    textStyle: { fontFamily, fontSize: 14, color: colors.text, fontWeight: 'bold' }
                 },
                 radar: {
                     indicator: indicator,
                     radius: '60%',
                     center: ['50%', '60%'],
-                    axisName: { color: colors.text, fontSize: 10 },
+                    axisName: { fontFamily, color: colors.text, fontSize: 10 },
                     splitLine: { lineStyle: { color: colors.grid } },
                     splitArea: { show: false }
                 },


### PR DESCRIPTION
问题描述：`statistics.svelte` 里面的 ECharts `setOption(……)` 没有指定任何 `fontFamily`，ECharts 默认使用默认的字体。导致图表文字与全局字体不一致。

改动内容：从页面的 `getComputedStyle(...).fontFamily` 读取实际生效的字体，并写入 ECharts 的 `textStyle.fontFamily`。也补齐了 `title.textStyle` 、`axisLabel/axisName` 的 `fontFamily`。

影响范围：只修改了 `statistics.svelte`。没有改变数据和交互逻辑，只影响了图表文字的字体，使字体与全局字体一致。

本地测试：已在本地通过 `pnpm dev` 进行测试。右侧的「统计」的字体已经跟全局一致。

<details>
  <summary>截图对比（点击展开）</summary>

  <p><b>默认字体：</b></p>
  <img width="320" height="1175" alt="Snipaste_2026-01-23_16-19-39" src="https://github.com/user-attachments/assets/45108433-d258-4d68-adfe-9492f6ddb421" />

  <p><b>LXGWWenKaiScreen：</b></p>
  <img width="320" height="1174" alt="Snipaste_2026-01-23_16-21-14" src="https://github.com/user-attachments/assets/899283f2-79c0-4fc5-b2c6-dd513899c9ae" />
  <img width="320" height="1161" alt="Snipaste_2026-01-23_16-21-29" src="https://github.com/user-attachments/assets/2b61632e-7e99-4ef9-bcbf-b9d87801bcbb" />

</details>



