### PR TITLE
fix/particles-flicker

### DIFF
--- a/src/utils/particle.ts
+++ b/src/utils/particle.ts
@@ -2,6 +2,8 @@ import type { ParticleConfig } from "@/types/config";
 import { particleConfig } from "@/config";
 
 
+const BOUNDARY_OFFSET = 100;
+
 // 粒子对象类
 class Particle {
     x: number;
@@ -67,8 +69,8 @@ class Particle {
         if (
             this.x > window.innerWidth ||
             this.x < 0 ||
-            this.y > window.innerHeight + 100 ||
-            this.y < -100 || // 从顶部消失
+            this.y > window.innerHeight + BOUNDARY_OFFSET ||
+            this.y < -BOUNDARY_OFFSET || // 从顶部消失
             this.a <= 0
         ) {
             // 如果粒子不做限制
@@ -89,7 +91,7 @@ class Particle {
         this.r = getRandom("fnr", this.config);
         if (Math.random() > 0.4) {
             this.x = getRandom("x", this.config);
-            this.y = window.innerHeight + Math.random() * 100; // 从屏幕底部开始
+            this.y = window.innerHeight + Math.random() * BOUNDARY_OFFSET; // 从屏幕底部开始
             this.s = getRandom("s", this.config);
             this.r = getRandom("r", this.config);
             this.a = getRandom('a', this.config);
@@ -146,7 +148,7 @@ function getRandom(option: string, config: ParticleConfig): any {
             ret = Math.random() * window.innerWidth;
             break;
         case "y":
-            ret = window.innerHeight + Math.random() * 100; // 初始位置在屏幕底部
+            ret = window.innerHeight + Math.random() * BOUNDARY_OFFSET; // 初始位置在屏幕底部
             break;
         case "s":
             ret =


### PR DESCRIPTION
问题描述：底部粒子特效的出现区域会出现明显的闪烁。具体表现为：粒子刚刷新出来就立刻消失，底部区域会反复多次出现。

改动内容：将越界判定调整为 `y > window.innerHeight + 100`，使越界边界与出生区间一致，避免立即重置造成的闪烁。

影响范围：只修改了 `particle.ts`。不改变粒子的数量、速度、透明度等配置，也不改变交互逻辑，仅修复底部闪烁现象。

本地测试：已经在本地通过 `pnpm dev` 进行测试。多次刷新页面后，底部区域不再出现粒子马上出现后就消失的情况（闪烁消除）。