### PR TITLE
修复atom订阅

### DIFF
--- a/src/pages/atom.xml.ts
+++ b/src/pages/atom.xml.ts
@@ -13,6 +13,19 @@ import { getFileDirFromPath, getPostUrl } from "@utils/url";
 
 const markdownParser = new MarkdownIt();
 
+function escapeXml(value: string) {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&apos;");
+}
+
+function wrapCdata(value: string) {
+    return value.replace(/]]>/g, "]]]]><![CDATA[>");
+}
+
 // get dynamic import of images as a map collection
 const imagesGlob = import.meta.glob<{ default: ImageMetadata }>(
     "/src/content/**/*.{jpeg,jpg,png,gif,webp}", // include posts and assets
@@ -30,13 +43,13 @@ export async function GET(context: APIContext) {
     // 创建Atom feed头部
     let atomFeed = `<?xml version="1.0" encoding="utf-8"?>
         <feed xmlns="http://www.w3.org/2005/Atom">
-        <title>${siteConfig.title}</title>
-        <subtitle>${siteConfig.subtitle || "No description"}</subtitle>
-        <link href="${context.site}" rel="alternate" type="text/html"/>
-        <link href="${new URL("atom.xml", context.site)}" rel="self" type="application/atom+xml"/>
-        <id>${context.site}</id>
+        <title>${escapeXml(siteConfig.title)}</title>
+        <subtitle>${escapeXml(siteConfig.subtitle || "No description")}</subtitle>
+        <link href="${escapeXml(context.site.href)}" rel="alternate" type="text/html"/>
+        <link href="${escapeXml(new URL("atom.xml", context.site).href)}" rel="self" type="application/atom+xml"/>
+        <id>${escapeXml(context.site.href)}</id>
         <updated>${new Date().toISOString()}</updated>
-        <language>${siteConfig.lang}</language>`;
+        <language>${escapeXml(siteConfig.lang)}</language>`;
 
     for (const post of posts) {
         // convert markdown to html string, ensure post.body is a string
@@ -103,15 +116,15 @@ export async function GET(context: APIContext) {
 
         atomFeed += `
         <entry>
-            <title>${post.data.title}</title>
-            <link href="${postUrl}" rel="alternate" type="text/html"/>
-            <id>${postUrl}</id>
+            <title>${escapeXml(post.data.title)}</title>
+            <link href="${escapeXml(postUrl)}" rel="alternate" type="text/html"/>
+            <id>${escapeXml(postUrl)}</id>
             <published>${post.data.published.toISOString()}</published>
             <updated>${post.data.updated?.toISOString() || post.data.published.toISOString()}</updated>
-            <summary>${post.data.description || ""}</summary>
-            <content type="html"><![CDATA[${content}]]></content>
+            <summary>${escapeXml(post.data.description || "")}</summary>
+            <content type="html"><![CDATA[${wrapCdata(content)}]]></content>
             <author>
-                <name>${profileConfig.name}</name>
+                <name>${escapeXml(profileConfig.name)}</name>
             </author>`;
         // 添加分类标签
         const categoryParts = getCategoryPathParts(post.data.category);
@@ -119,7 +132,7 @@ export async function GET(context: APIContext) {
             for (let i = 0; i < categoryParts.length; i++) {
                 const term = categoryParts.slice(0, i + 1).join(" / ");
                 atomFeed += `
-            <category term="${term}"></category>`;
+            <category term="${escapeXml(term)}"></category>`;
             }
         }
         // 添加标签
@@ -127,7 +140,7 @@ export async function GET(context: APIContext) {
         if (postTags && postTags.length > 0) {
             for (const tag of postTags) {
                 atomFeed += `
-            <category term="${tag}" label="${tag}"></category>`;
+            <category term="${escapeXml(tag)}" label="${escapeXml(tag)}"></category>`;
             }
         }
         atomFeed += `


### PR DESCRIPTION
文章标题包含“&”等字符时未进行转义，导致atom订阅构建失败

## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):


## Checklist

- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new issues.


## Changes

修复`atom.xml.ts`文件，为特殊字符添加转义，避免atom订阅构建失败


## How To Test

修复前，如果有文章标题包含“&”字符，访问atom订阅时会返回如下报错：

<img width="1070" height="294" alt="image" src="https://github.com/user-attachments/assets/b6da64bc-4441-4811-b2eb-0060d64c80f3" />

修复后即正常生成atom订阅

