### PR TITLE
Add 'directoryTitle' support

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -25,6 +25,7 @@ const postsCollection = defineCollection({
     loader: glob({ pattern: '**/[^_]*.{md,mdx}', base: "./src/content/posts" }),
     schema: z.object({
         title: z.string(),
+        directoryTitle: z.string().optional().default(""),
         published: optionalDateSchema,
         updated: optionalDateSchema,
         description: z.string().optional().default(""),

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -25,7 +25,7 @@ const postsCollection = defineCollection({
     loader: glob({ pattern: '**/[^_]*.{md,mdx}', base: "./src/content/posts" }),
     schema: z.object({
         title: z.string(),
-        directoryTitle: z.string().optional().default(""),
+        directoryTitle: z.string().optional().default("").transform(s => s.trim()),
         published: optionalDateSchema,
         updated: optionalDateSchema,
         description: z.string().optional().default(""),

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -352,22 +352,6 @@ export type SidebarConfig = {
  * 
  */
 
-export type BlogPostData = {
-    body: string;
-    title: string;
-    published: Date;
-    description: string;
-    tags: string[];
-    draft?: boolean;
-    image?: string;
-    category?: string;
-    pinned?: boolean;
-    prevTitle?: string;
-    prevSlug?: string;
-    nextTitle?: string;
-    nextSlug?: string;
-};
-
 
 // 评论服务提供商
 export type CommentProvider = "waline" |"twikoo";

--- a/src/utils/directory.ts
+++ b/src/utils/directory.ts
@@ -44,7 +44,7 @@ export async function getDirectoryTree(): Promise<DirectoryNode[]> {
         const parts = post.id.split('/');
         const fileName = parts.pop()!;
         const paths = [rootMap.posts, ...parts];
-        addNode(paths, post.data.title || fileName, `/posts/${post.id}/`);
+        addNode(paths, post.data.directoryTitle || post.data.title || fileName, `/posts/${post.id}/`);
     }
 
     for (const album of sortedAlbums) {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):


## Checklist

- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new issues.


## Changes

Resolve issue #158

---
第一次做PR，請多指教

新增目錄專用標題的支援，在文章的front matter設置`directoryTitle`來修改在目錄中的標題

另外，原本文章在目錄中的標題在`post.data.title`未填寫時有`fileName` fallback，可是`title`是必填項目，所以`fileName`應該是unreachable的，可考慮移除

---

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
<img width="730" height="382" alt="image" src="https://github.com/user-attachments/assets/0b3d1fe6-00c9-47b6-936e-cee9e6ce5242" />